### PR TITLE
Workaround if bluepill does not support conf_dir

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -105,7 +105,7 @@ end
 def delegate_action(action)
   bluepill_service new_resource.service_name do
     action action
-    conf_dir pill_file_dir
+    Chef::Resource::BluepillService.respond_to?(:conf_dir) ? conf_dir(pill_file_dir) : node.set['bluepill']['conf_dir'] = pill_file_dir
   end
 end
 


### PR DESCRIPTION
Public cookbook bluepill 2.3.1 http://community.opscode.com/cookbooks/bluepill it does not appear to support conf_dir, so we needed this workaround in order to use the datomic cookbook https://github.com/RallySoftware-cookbooks/datomic.

Fixes https://github.com/RallySoftware-cookbooks/datomic/issues/4
